### PR TITLE
NXP-20665: fix dc:modified value in test to have default timezone

### DIFF
--- a/nuxeo-opencmis-impl/src/main/java/org/nuxeo/ecm/core/opencmis/impl/server/NuxeoCmisService.java
+++ b/nuxeo-opencmis-impl/src/main/java/org/nuxeo/ecm/core/opencmis/impl/server/NuxeoCmisService.java
@@ -92,6 +92,7 @@ import org.apache.chemistry.opencmis.commons.exceptions.CmisInvalidArgumentExcep
 import org.apache.chemistry.opencmis.commons.exceptions.CmisNotSupportedException;
 import org.apache.chemistry.opencmis.commons.exceptions.CmisObjectNotFoundException;
 import org.apache.chemistry.opencmis.commons.exceptions.CmisRuntimeException;
+import org.apache.chemistry.opencmis.commons.exceptions.CmisUpdateConflictException;
 import org.apache.chemistry.opencmis.commons.impl.WSConverter;
 import org.apache.chemistry.opencmis.commons.impl.dataobjects.AbstractPropertyData;
 import org.apache.chemistry.opencmis.commons.impl.dataobjects.BindingsObjectFactoryImpl;
@@ -607,7 +608,7 @@ public class NuxeoCmisService extends AbstractCmisService
         }
 
         NuxeoObjectData data = new NuxeoObjectData(this, doc);
-        updateProperties(data, null, properties, true);
+        updateProperties(data, properties, true);
         boolean setContentStream = !created && contentStream != null;
         if (setContentStream) {
             try {
@@ -637,10 +638,8 @@ public class NuxeoCmisService extends AbstractCmisService
         return data;
     }
 
-    protected <T> void updateProperties(NuxeoObjectData object, String changeToken, Properties properties,
-            boolean creation) {
+    protected <T> void updateProperties(NuxeoObjectData object, Properties properties, boolean creation) {
         List<TypeDefinition> types = object.getTypeDefinitions();
-        // TODO changeToken
         Map<String, PropertyData<?>> p;
         if (properties == null || (p = properties.getProperties()) == null) {
             return;
@@ -652,9 +651,8 @@ public class NuxeoCmisService extends AbstractCmisService
         }
     }
 
-    protected <T> void updateProperties(NuxeoObjectData object, String changeToken, Map<String, ?> properties,
-            TypeDefinition type, boolean creation) {
-        // TODO changeToken
+    protected <T> void updateProperties(NuxeoObjectData object, Map<String, ?> properties, TypeDefinition type,
+            boolean creation) {
         if (properties == null) {
             return;
         }
@@ -795,7 +793,7 @@ public class NuxeoCmisService extends AbstractCmisService
         DocumentModel copyDoc = coreSession.copy(doc.getRef(), folder.getRef(), null);
         NuxeoObjectData copy = new NuxeoObjectData(this, copyDoc);
         if (properties != null && properties.getPropertyList() != null && !properties.getPropertyList().isEmpty()) {
-            updateProperties(copy, null, properties, false);
+            updateProperties(copy, properties, false);
             copy.doc = coreSession.saveDocument(copyDoc);
         }
         save();
@@ -810,7 +808,7 @@ public class NuxeoCmisService extends AbstractCmisService
         DocumentModel copyDoc = coreSession.copy(doc.getRef(), folder.getRef(), null);
         NuxeoObjectData copy = new NuxeoObjectData(this, copyDoc, context);
         if (properties != null && !properties.isEmpty()) {
-            updateProperties(copy, null, properties, type, false);
+            updateProperties(copy, properties, type, false);
             copy.doc = coreSession.saveDocument(copyDoc);
         }
         save();
@@ -1132,6 +1130,9 @@ public class NuxeoCmisService extends AbstractCmisService
         }
 
         DocumentModel doc = getDocumentModel(objectId);
+        String operation = contentStream == null ? "deleteContentStream" : "setContentStream";
+        verifyChangeToken(doc, changeTokenHolder, operation);
+
         // TODO test doc checkout state
         try {
             NuxeoPropertyData.setContentStream(doc, contentStream, !Boolean.FALSE.equals(overwriteFlag));
@@ -1140,6 +1141,26 @@ public class NuxeoCmisService extends AbstractCmisService
             save();
         } catch (IOException e) {
             throw new CmisRuntimeException(e.toString(), e);
+        }
+    }
+
+    protected void verifyChangeToken(DocumentModel doc, Holder<String> changeTokenHolder, String operation) {
+        if (doc == null) {
+            return;
+        }
+        String docChangeToken = doc.getChangeToken();
+        if (StringUtils.isBlank(docChangeToken)) {
+            return;
+        }
+        String reqChangeToken = changeTokenHolder == null ? null : changeTokenHolder.getValue();
+        if (!docChangeToken.equals(reqChangeToken)) {
+            String message = String.format(
+                    "Request %s failed because supplied changeToken: '%s' does not match existing changeToken: '%s'",
+                    operation, reqChangeToken, docChangeToken);
+            new Error(message).printStackTrace();
+            throw new CmisUpdateConflictException(String.format(
+                    "Request %s failed because supplied changeToken: '%s' does not match existing changeToken: '%s'",
+                    operation, reqChangeToken, docChangeToken));
         }
     }
 
@@ -1158,9 +1179,9 @@ public class NuxeoCmisService extends AbstractCmisService
             throw new CmisInvalidArgumentException("Missing object ID");
         }
         DocumentModel doc = getDocumentModel(objectId);
+        verifyChangeToken(doc, changeTokenHolder, "updateProperties");
         NuxeoObjectData object = new NuxeoObjectData(this, doc);
-        String changeToken = changeTokenHolder == null ? null : changeTokenHolder.getValue();
-        updateProperties(object, changeToken, properties, false);
+        updateProperties(object, properties, false);
         coreSession.saveDocument(doc);
     }
 
@@ -1941,7 +1962,7 @@ public class NuxeoCmisService extends AbstractCmisService
         DocumentModel doc = getDocumentModel(objectId);
 
         NuxeoObjectData object = new NuxeoObjectData(this, doc);
-        updateProperties(object, null, properties, false);
+        updateProperties(object, properties, false);
         boolean setContentStream = contentStream != null;
         if (setContentStream) {
             try {

--- a/nuxeo-opencmis-impl/src/main/java/org/nuxeo/ecm/core/opencmis/impl/server/NuxeoPropertyData.java
+++ b/nuxeo-opencmis-impl/src/main/java/org/nuxeo/ecm/core/opencmis/impl/server/NuxeoPropertyData.java
@@ -141,7 +141,8 @@ public abstract class NuxeoPropertyData<T> extends NuxeoPropertyDataBase<T> {
             return (PropertyData<U>) new NuxeoPropertyDateTimeData((PropertyDefinition<GregorianCalendar>) pd, doc,
                     NuxeoTypeHelper.NX_DC_MODIFIED, true, callContext);
         } else if (PropertyIds.CHANGE_TOKEN.equals(name)) {
-            return (PropertyData<U>) new NuxeoPropertyStringDataFixed((PropertyDefinition<String>) pd, null);
+            return (PropertyData<U>) new NuxeoPropertyStringDataFixed((PropertyDefinition<String>) pd,
+                    doc.getChangeToken());
         } else if (PropertyIds.NAME.equals(name)) {
             return (PropertyData<U>) new NuxeoPropertyDataName((PropertyDefinition<String>) pd, doc);
         } else if (PropertyIds.IS_IMMUTABLE.equals(name)) {

--- a/nuxeo-opencmis-tests/src/main/java/org/nuxeo/ecm/core/opencmis/tests/Helper.java
+++ b/nuxeo-opencmis-tests/src/main/java/org/nuxeo/ecm/core/opencmis/tests/Helper.java
@@ -126,7 +126,7 @@ public class Helper {
         blob1.setDigest(DigestUtils.md5Hex(content));
         blob1.setFilename(filename);
         file1.setPropertyValue("content", (Serializable) blob1);
-        Calendar cal1 = getCalendar(2007, 3, 1, 12, 0, 0);
+        Calendar cal1 = getCalendar(2007, 3, 1, 12, 0, 0, TimeZone.getDefault());
         file1.setPropertyValue("dc:created", cal1);
         file1.setPropertyValue("dc:modified", cal1);
         file1.setPropertyValue("dc:creator", "michael");

--- a/nuxeo-opencmis-tests/src/test/java/org/nuxeo/ecm/core/opencmis/impl/CmisSuiteSession2.java
+++ b/nuxeo-opencmis-tests/src/test/java/org/nuxeo/ecm/core/opencmis/impl/CmisSuiteSession2.java
@@ -218,12 +218,15 @@ public class CmisSuiteSession2 {
         return entity;
     }
 
-    protected HttpEntity getSetContentStreamHttpEntity(File file) {
+    protected HttpEntity getSetContentStreamHttpEntity(File file, String changeToken) {
         FormBodyPart cmisactionPart = FormBodyPartBuilder.create("cmisaction",
                 new StringBody("setContent", ContentType.TEXT_PLAIN)).build();
         FormBodyPart contentPart = FormBodyPartBuilder.create("content",
                 new FileBody(file, ContentType.TEXT_PLAIN, "testfile.txt")).build();
-        HttpEntity entity = MultipartEntityBuilder.create().addPart(cmisactionPart).addPart(contentPart).build();
+        HttpEntity entity = MultipartEntityBuilder.create()
+                .addPart(cmisactionPart)
+                .addTextBody("changeToken", changeToken)
+                .addPart(contentPart).build();
         return entity;
     }
 
@@ -341,7 +344,10 @@ public class CmisSuiteSession2 {
                 boolean okRequest = i == 0;
 
                 request.setHeader("Digest", "md5=" + (String) (okRequest ? contentMD5Base64 : "bogusMD5Sum"));
-                HttpEntity reqEntity = getSetContentStreamHttpEntity(files[i]);
+                session.clear();
+                String changeToken = session.getObjectByPath("/testfolder1/testfile1").getChangeToken();
+                System.err.println("Passing change token: " + changeToken);
+                HttpEntity reqEntity = getSetContentStreamHttpEntity(files[i], changeToken);
                 request.setEntity(reqEntity);
                 try (CloseableHttpResponse response = httpClient.execute(request)) {
                     if (okRequest) {

--- a/nuxeo-opencmis-tests/src/test/java/org/nuxeo/ecm/core/opencmis/impl/TestCmisBinding.java
+++ b/nuxeo-opencmis-tests/src/test/java/org/nuxeo/ecm/core/opencmis/impl/TestCmisBinding.java
@@ -70,6 +70,7 @@ import java.math.BigDecimal;
 import java.math.BigInteger;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Calendar;
 import java.util.Collections;
 import java.util.EnumSet;
 import java.util.GregorianCalendar;
@@ -126,6 +127,7 @@ import org.apache.chemistry.opencmis.commons.exceptions.CmisConstraintException;
 import org.apache.chemistry.opencmis.commons.exceptions.CmisInvalidArgumentException;
 import org.apache.chemistry.opencmis.commons.exceptions.CmisObjectNotFoundException;
 import org.apache.chemistry.opencmis.commons.exceptions.CmisRuntimeException;
+import org.apache.chemistry.opencmis.commons.exceptions.CmisUpdateConflictException;
 import org.apache.chemistry.opencmis.commons.impl.dataobjects.AccessControlEntryImpl;
 import org.apache.chemistry.opencmis.commons.impl.dataobjects.AccessControlListImpl;
 import org.apache.chemistry.opencmis.commons.impl.dataobjects.AccessControlPrincipalDataImpl;
@@ -775,18 +777,36 @@ public class TestCmisBinding extends TestCmisBindingBase {
         }
     }
 
+    protected Holder<String> getChangeTokenHolder(ObjectData ob) {
+        return getChangeTokenHolder(ob.getProperties());
+    }
+
+    protected Holder<String> getChangeTokenHolder(Properties p) {
+        return new Holder<>((String) p.getProperties().get("cmis:changeToken").getFirstValue());
+    }
+
     @Test
     public void testUpdateProperties() throws Exception {
         ObjectData ob = getObjectByPath("/testfolder1/testfile1");
         assertEquals("testfile1_Title", getString(ob, "dc:title"));
-
         Properties props = createProperties("dc:title", "new title");
         Holder<String> objectIdHolder = new Holder<>(ob.getId());
-        objService.updateProperties(repositoryId, objectIdHolder, null, props, null);
+        Holder<String> changeTokenHolder = getChangeTokenHolder(ob);
+        objService.updateProperties(repositoryId, objectIdHolder, changeTokenHolder, props, null);
         assertEquals(ob.getId(), objectIdHolder.getValue());
 
         ob = getObject(ob.getId());
         assertEquals("new title", getString(ob, "dc:title"));
+
+        Holder<String>[] changeTokenHolders = new Holder[] { new Holder<>(null), new Holder<>("bogusChangeToken") };
+        for (int i = 0; i < changeTokenHolders.length; i++) {
+            try {
+                objService.updateProperties(repositoryId, objectIdHolder, changeTokenHolders[i], props, null);
+                fail(String.format("updateProperties with '%s' cmis:changeToken should fail", changeTokenHolders[i]));
+            } catch (CmisUpdateConflictException e) {
+                // ok
+            }
+        }
     }
 
     @Test
@@ -805,9 +825,13 @@ public class TestCmisBinding extends TestCmisBindingBase {
         assertEquals(Collections.emptyList(), v.getValues());
 
         // null value from NuxeoPropertyStringDataFixed
-        v = p.getProperties().get("cmis:changeToken");
+        v = p.getProperties().get("nuxeo:pos");
         assertNull(v.getFirstValue());
         assertEquals(Collections.emptyList(), v.getValues());
+
+        v = p.getProperties().get("cmis:changeToken");
+        Calendar lastModified = (Calendar) p.getProperties().get("dc:modified").getFirstValue();
+        assertEquals(Long.toString(lastModified.getTimeInMillis()), v.getFirstValue());
 
         // with filter
         p = objService.getProperties(repositoryId, ob.getId(), "cmis:name", null);
@@ -842,7 +866,8 @@ public class TestCmisBinding extends TestCmisBindingBase {
         // change secondary prop
         Properties props = createProperties("my2:string", "bar");
         Holder<String> objectIdHolder = new Holder<String>(ob.getId());
-        objService.updateProperties(repositoryId, objectIdHolder, null, props, null);
+        Holder<String> changeTokenHolder = getChangeTokenHolder(p);
+        objService.updateProperties(repositoryId, objectIdHolder, changeTokenHolder, props, null);
 
         // re-fetch
         p = objService.getProperties(repositoryId, ob.getId(), null, null);
@@ -871,8 +896,20 @@ public class TestCmisBinding extends TestCmisBindingBase {
 
         cs = new ContentStreamImpl("foo.txt", "text/plain; charset=UTF-8", STREAM_CONTENT);
         Holder<String> objectIdHolder = new Holder<>(ob.getId());
-        objService.setContentStream(repositoryId, objectIdHolder, Boolean.TRUE, null, cs, null);
+        Holder<String> changeTokenHolder = getChangeTokenHolder(ob);
+        objService.setContentStream(repositoryId, objectIdHolder, Boolean.TRUE, changeTokenHolder, cs, null);
         assertEquals(ob.getId(), objectIdHolder.getValue());
+
+        Holder<String>[] changeTokenHolders = new Holder[] { new Holder<>(null), new Holder<>("bogusChangeToken") };
+        for (int i = 0; i < changeTokenHolders.length; i++) {
+            try {
+                objService.setContentStream(repositoryId, objectIdHolder, Boolean.TRUE,
+                        changeTokenHolders[i], cs, null);
+                fail(String.format("setContentStream with '%s' cmis:changeToken should fail", changeTokenHolders[i]));
+            } catch (CmisUpdateConflictException e) {
+                // ok
+            }
+        }
 
         // refetch
         cs = objService.getContentStream(repositoryId, ob.getId(), null, null, null, null);
@@ -883,7 +920,18 @@ public class TestCmisBinding extends TestCmisBindingBase {
         assertEquals(STREAM_CONTENT, Helper.read(cs.getStream(), "UTF-8"));
 
         // delete
-        objService.deleteContentStream(repositoryId, objectIdHolder, null, null);
+        ob = objService.getObject(repositoryId, ob.getId(), null, null, null, null, null, null, null);
+        changeTokenHolder = getChangeTokenHolder(ob);
+        objService.deleteContentStream(repositoryId, objectIdHolder, changeTokenHolder, null);
+
+        for (int i = 0; i < changeTokenHolders.length; i++) {
+            try {
+                objService.deleteContentStream(repositoryId, objectIdHolder, changeTokenHolders[i], null);
+                fail(String.format("deleteContentStream with '%s' cmis:changeToken should fail", changeTokenHolders[i]));
+            } catch (CmisUpdateConflictException e) {
+                // ok
+            }
+        }
 
         // refetch
         try {
@@ -1529,7 +1577,7 @@ public class TestCmisBinding extends TestCmisBindingBase {
         checkReturnedValue(PropertyIds.CREATION_DATE, NOT_NULL);
         checkReturnedValue(PropertyIds.LAST_MODIFIED_BY, "john");
         checkReturnedValue(PropertyIds.LAST_MODIFICATION_DATE, NOT_NULL);
-        checkReturnedValue(PropertyIds.CHANGE_TOKEN, null);
+        checkReturnedValue(PropertyIds.CHANGE_TOKEN, NOT_NULL);
         checkReturnedValue(NuxeoTypeHelper.NX_PARENT_ID, NOT_NULL);
 
         // ----- Folder -----
@@ -1798,7 +1846,8 @@ public class TestCmisBinding extends TestCmisBindingBase {
 
         Properties props = createProperties("dc:description", "new description");
         idHolder = new Holder<>(ob.getId());
-        objService.updateProperties(repositoryId, idHolder, null, props, null);
+        Holder<String> changeTokenHolder = getChangeTokenHolder(ob);
+        objService.updateProperties(repositoryId, idHolder, changeTokenHolder, props, null);
         assertEquals(ob.getId(), idHolder.getValue());
 
         waitForIndexing();
@@ -2172,10 +2221,10 @@ public class TestCmisBinding extends TestCmisBindingBase {
         Properties properties = factory.createPropertiesData(Arrays.asList(propTitle, propDescription));
 
         Holder<String> objectIdHolder = new Holder<>(ob.getId());
-        objService.updateProperties(repositoryId, objectIdHolder, null, properties, null);
+        Holder<String> changeTokenHolder = getChangeTokenHolder(ob);
+        objService.updateProperties(repositoryId, objectIdHolder, changeTokenHolder, properties, null);
 
         sleepForFulltext();
-
         waitForIndexing();
 
         ObjectList res;
@@ -2228,7 +2277,8 @@ public class TestCmisBinding extends TestCmisBindingBase {
         Properties properties = factory.createPropertiesData(Arrays.asList(propTitle, propDescription));
 
         Holder<String> objectIdHolder = new Holder<>(ob.getId());
-        objService.updateProperties(repositoryId, objectIdHolder, null, properties, null);
+        Holder<String> changeTokenHolder = getChangeTokenHolder(ob);
+        objService.updateProperties(repositoryId, objectIdHolder, changeTokenHolder, properties, null);
 
         sleepForFulltext();
         waitForIndexing();
@@ -2250,10 +2300,10 @@ public class TestCmisBinding extends TestCmisBindingBase {
         Properties properties = factory.createPropertiesData(Arrays.asList(propTitle, propDescription));
 
         Holder<String> objectIdHolder = new Holder<>(ob.getId());
-        objService.updateProperties(repositoryId, objectIdHolder, null, properties, null);
+        Holder<String> changeTokenHolder = getChangeTokenHolder(ob);
+        objService.updateProperties(repositoryId, objectIdHolder, changeTokenHolder, properties, null);
 
         sleepForFulltext();
-
         waitForIndexing();
 
         ObjectList res;

--- a/nuxeo-opencmis-tests/src/test/java/org/nuxeo/ecm/core/opencmis/impl/TestCmisBindingComplexProperties.java
+++ b/nuxeo-opencmis-tests/src/test/java/org/nuxeo/ecm/core/opencmis/impl/TestCmisBindingComplexProperties.java
@@ -200,7 +200,8 @@ public class TestCmisBindingComplexProperties extends TestCmisBindingBase {
         PropertyString prop = bof.createPropertyStringData("complexTest:listItem", stringArr);
         Properties props = bof.createPropertiesData(Collections.<PropertyData<?>> singletonList(prop));
         Holder<String> objectIdHolder = new Holder<String>(doc.getId());
-        objService.updateProperties(repositoryId, objectIdHolder, null, props, null);
+        Holder<String> changeTokenHolder = new Holder<String>(doc.getChangeToken());
+        objService.updateProperties(repositoryId, objectIdHolder, changeTokenHolder, props, null);
 
         // Verify the properties produced in Nuxeo match the input JSON
         session.save();
@@ -309,7 +310,8 @@ public class TestCmisBindingComplexProperties extends TestCmisBindingBase {
         // Set the property as a JSON string through the CMIS service
         Properties props = createProperties("complexTest:complexItem", jsonStr);
         Holder<String> objectIdHolder = new Holder<String>(doc.getId());
-        objService.updateProperties(repositoryId, objectIdHolder, null, props, null);
+        Holder<String> changeTokenHolder = new Holder<String>(doc.getChangeToken());
+        objService.updateProperties(repositoryId, objectIdHolder, changeTokenHolder, props, null);
 
         // Verify the properties produced in Nuxeo match the input JSON
         session.save();

--- a/nuxeo-opencmis-tests/src/test/resources/log4j.xml
+++ b/nuxeo-opencmis-tests/src/test/resources/log4j.xml
@@ -28,7 +28,7 @@
   </category>
 
   <root>
-    <priority value="TRACE" />
+    <priority value="WARN" />
     <appender-ref ref="CONSOLE" />
   </root>
 

--- a/nuxeo-opencmis-tests/src/test/resources/log4j.xml
+++ b/nuxeo-opencmis-tests/src/test/resources/log4j.xml
@@ -28,7 +28,7 @@
   </category>
 
   <root>
-    <priority value="WARN" />
+    <priority value="TRACE" />
     <appender-ref ref="CONSOLE" />
   </root>
 


### PR DESCRIPTION
Until NXP-12220 is implemented, it is important that date fields such as dc:created, dc:modified, etc. share the same timezone as the server.