### PR TITLE
NXP-19858: DBS does not support multiple CONTAINS

### DIFF
--- a/nuxeo-opencmis-impl/src/main/resources/OSGI-INF/properties-contrib.xml
+++ b/nuxeo-opencmis-impl/src/main/resources/OSGI-INF/properties-contrib.xml
@@ -11,7 +11,8 @@
           Relaxing CMIS specification control, default to false. Setting this property to true allows users to relax
           the CMIS specification and use customized CMISQL. It allows multiple CONTAINS in CMISQL, contrary to the
           specification 1.1, section 2.1.14.2.4.4, where at most one CONTAINS() function must be included in a single
-          query statement. Currently, JOIN predicate is not supported in such mode.
+          query statement. Currently, JOIN predicate is not supported in such mode. This relax mode must NOT be used
+          with DBS (Document-Based Storage), like MongoDB or MarkLogic.
         </li>
         <li>
           "org.nuxeo.cmis.errorOnCancelCheckOutOfDraftVersion":

--- a/nuxeo-opencmis-tests/src/test/java/org/nuxeo/ecm/core/opencmis/impl/TestCmisBinding.java
+++ b/nuxeo-opencmis-tests/src/test/java/org/nuxeo/ecm/core/opencmis/impl/TestCmisBinding.java
@@ -2276,6 +2276,7 @@ public class TestCmisBinding extends TestCmisBindingBase {
     @LocalDeploy("org.nuxeo.ecm.core.opencmis.tests.tests:OSGI-INF/test-relax-cmis-spec.xml")
     public void testQueryMultiContainsRelaxingSpec() throws Exception {
 
+        assumeFalse("DBS does not support multiple CONTAINS", coreFeature.getStorageConfiguration().isDBS());
         // when using JOINs, we use the CMISQLQueryMaker which hasn't been updated to allow multiple CONTAINs
         assumeFalse("JOINs are not supported", supportsJoins());
 


### PR DESCRIPTION
Avoid using the relax mode with DBS (Document-Based Storage), like MongoDB or MarkLogic, because multiple CONTAINS is not supported. Using relax mode mistakenly leads to an CMIS runtime exception<sup>[1]</sup> with error message:

    Query failed with error code 2 and error message 'Too many text expressions' on server ...

See [Jenkins QA][qa] for more detail.

[qa]: https://qa.nuxeo.org/jenkins/job/master/job/nuxeo-master-fullbuild-multidb-linux-relax/63/Slave=MULTIDB_LINUX,dbprofile=mongodb,jdk=java-8-oracle/testReport/junit/org.nuxeo.ecm.core.opencmis.impl/TestCmisBinding/testQueryMultiContainsRelaxingSpec/

<sup>[1]</sup>: org.apache.chemistry.opencmis.commons.exceptions.CmisRuntimeException