### PR TITLE
NXP-21968: Fix unit tests after removing root indexing

### DIFF
--- a/nuxeo-opencmis-tests/src/test/java/org/nuxeo/ecm/core/opencmis/impl/TestCmisBindingES.java
+++ b/nuxeo-opencmis-tests/src/test/java/org/nuxeo/ecm/core/opencmis/impl/TestCmisBindingES.java
@@ -46,7 +46,8 @@ public class TestCmisBindingES extends TestCmisBinding {
 
     @Override
     protected boolean returnsRootInFolderQueries() {
-        return true;
+        // since NXP-21968 root is not indexed anymore
+        return false;
     }
 
     @Override


### PR DESCRIPTION
T&P: https://qa.nuxeo.org/jenkins/job/TestAndPush/job/ondemand-testandpush-kleturc-2/29