### PR TITLE
fix-NXP-24531-versionVersionableId-on-elastic-backport-9.10

### DIFF
--- a/nuxeo-opencmis-tests/src/test/java/org/nuxeo/ecm/core/opencmis/impl/TestCmisBinding.java
+++ b/nuxeo-opencmis-tests/src/test/java/org/nuxeo/ecm/core/opencmis/impl/TestCmisBinding.java
@@ -1645,11 +1645,7 @@ public class TestCmisBinding extends TestCmisBindingBase {
         checkReturnedValue(PropertyIds.IS_LATEST_VERSION, Boolean.FALSE);
         checkReturnedValue(PropertyIds.IS_MAJOR_VERSION, Boolean.FALSE);
         checkReturnedValue(PropertyIds.IS_LATEST_MAJOR_VERSION, Boolean.FALSE);
-        if (useElasticsearch()) {
-            checkReturnedValue(PropertyIds.VERSION_LABEL, "0.0");
-        } else {
-            checkReturnedValue(PropertyIds.VERSION_LABEL, null);
-        }
+        checkReturnedValue(PropertyIds.VERSION_LABEL, null);
         checkReturnedValue(PropertyIds.VERSION_SERIES_ID, NOT_NULL);
         checkReturnedValue(PropertyIds.IS_VERSION_SERIES_CHECKED_OUT, Boolean.TRUE);
         checkReturnedValue(PropertyIds.IS_PRIVATE_WORKING_COPY, Boolean.TRUE);


### PR DESCRIPTION
PR created from https://qa2.nuxeo.org/jenkins/job/TestAndPush/job/ondemand-testandpush-gethin-9.10/10/